### PR TITLE
refatoração visual

### DIFF
--- a/lib/presentation/pages/connect_page_screen.dart
+++ b/lib/presentation/pages/connect_page_screen.dart
@@ -245,7 +245,7 @@ class _ConnectPageState extends State<ConnectScreen> {
                         children: [
                           // Botão de voltar
                           Padding(
-                            padding: const EdgeInsets.all(16.0),
+                            padding: const EdgeInsets.all(8.0),
                             child: IconButton(
                               icon: Icon(
                                 Icons.arrow_back,


### PR DESCRIPTION
style: Ajusta padding do botão de voltar na tela de conexão
- Reduz o padding do botão `IconButton` (seta de voltar) de `16.0` para `8.0` dentro do widget `Padding`.