### PR TITLE
fix(forms): remove espaços em branco no envio e corrige botão de reto…

### DIFF
--- a/lib/presentation/pages/connect_page_screen.dart
+++ b/lib/presentation/pages/connect_page_screen.dart
@@ -50,7 +50,7 @@ class _ConnectPageState extends State<ConnectScreen> {
 
   // Função para validar o campo de username
   void _validateUsername() {
-    final username = _usernameController.text;
+    final username = _usernameController.text.trim();
     if (_submitted) {
       setState(() {
         if (username.isEmpty) {
@@ -92,7 +92,7 @@ class _ConnectPageState extends State<ConnectScreen> {
     if (_isUsernameValid && _isPasswordValid) {
       try {
         await _loginService.login(
-          _usernameController.text,
+          _usernameController.text.trim(),
           _passwordController.text,
         );
 
@@ -127,7 +127,7 @@ class _ConnectPageState extends State<ConnectScreen> {
 
   //Metodo para login anonimo
   Future<void> _loginAnonimo() async {
-    if (_usernameController.text.isEmpty) {
+    if (_usernameController.text.trim().isEmpty) {
       final snackBar = SnackBarRejeitada(
         titulo: "Login Recusado",
         subtitulo: "O nome de usuário deve estar preenchido.",
@@ -151,7 +151,7 @@ class _ConnectPageState extends State<ConnectScreen> {
     if (shouldProceed != true) return; // Se não confirmou, cancela o login
 
     try {
-      await _userService.createAnonymousUser(_usernameController.text);
+      await _userService.createAnonymousUser(_usernameController.text.trim());
       final snackBar = SnackBarAceita(
         titulo: "Login realizado com sucesso!",
         subtitulo: "Bem-vindo(a) ao Roka Moka!",

--- a/lib/presentation/pages/qr_code_screen.dart
+++ b/lib/presentation/pages/qr_code_screen.dart
@@ -80,7 +80,7 @@ class _QRCodeScreenState extends State<QRCodeScreen> {
                       color: Colors.white,
                       size: 30,
                     ),
-                    onPressed: widget.onBack ?? () {},
+                    onPressed: widget.onBack ?? () => Navigator.pop(context),
                   ),
                 ),
               ),

--- a/lib/presentation/pages/send_email_forgot_password_screen.dart
+++ b/lib/presentation/pages/send_email_forgot_password_screen.dart
@@ -36,7 +36,7 @@ class _SendEmailForgotPasswordScreenState
     _mostrarLoading();
 
     try {
-      await userService.sendEmailForgotPassword(_emailController.text);
+      await userService.sendEmailForgotPassword(_emailController.text.trim());
 
       Navigator.pop(context);
 

--- a/lib/presentation/pages/signup_screen.dart
+++ b/lib/presentation/pages/signup_screen.dart
@@ -89,24 +89,26 @@ class _SignupPageState extends State<SignupScreen> {
   }
 
   String? _validateName(String name) {
+    final trimmedName = name.trim();
     final validPattern = RegExp(r'^[a-zA-Z0-9_-]+$');
-    if (_submitted && name.isEmpty) {
+    if (_submitted && trimmedName.isEmpty) {
       return 'O nome de usuário é obrigatório.';
     }
-    if (_submitted && !validPattern.hasMatch(name)) {
+    if (_submitted && !validPattern.hasMatch(trimmedName)) {
       return 'Apenas letras, números, hífen e underline são permitidos.';
     }
     return null;
   }
 
   String? _validateEmail(String email) {
+    final trimmedEmail = email.trim();
     if (_submitted) {
-      if (email.isEmpty) {
+      if (trimmedEmail.isEmpty) {
         return 'O email é obrigatório.';
       }
       if (!RegExp(
         r'^[\w-]+(\.[\w-]+)*@([\w-]+\.)+[a-zA-Z]{2,7}$',
-      ).hasMatch(email)) {
+      ).hasMatch(trimmedEmail)) {
         return 'Insira um email válido.';
       }
     }
@@ -164,11 +166,11 @@ class _SignupPageState extends State<SignupScreen> {
 
     try {
       await _userService.createUser(
-        _emailController.text,
+        _emailController.text.trim(),
         _passwordController.text,
-        _nameController.text,
-        _firstNameController.text,
-        _lastNameController.text,
+        _nameController.text.trim(),
+        _firstNameController.text.trim(),
+        _lastNameController.text.trim(),
       );
 
       context.read<UserProvider>().setRole(UserRole.comum);


### PR DESCRIPTION
…rno do QR

Aplica trim() ao enviar campos comuns (usuário, email, nome, sobrenome) no login, login anônimo, cadastro e envio de email de recuperação, evitando falhas de autenticação/criação por espaço acidental. As senhas não são alteradas. As validações de usuário e email no cadastro passam a ignorar espaços nas pontas para não bloquear a criação da conta.

Corrige o botão de retorno da tela de captura de QR: quando aberta sem callback onBack (via 'Coletar via QR Code'), agora usa Navigator.pop em vez de uma closure vazia.